### PR TITLE
awilix の loadModules が使えるようにビルドを工夫する

### DIFF
--- a/backend/src/app/http/connect.ts
+++ b/backend/src/app/http/connect.ts
@@ -1,6 +1,6 @@
 import type { ConnectRouter } from '@connectrpc/connect'
-import { registerHealthService } from './controller/health'
-import { container } from '../../container'
+import { registerHealthService } from './controller/health.js'
+import { container } from '../../container.js'
 
 export default (router: ConnectRouter) => {
   registerHealthService(

--- a/backend/src/app/http/controller/health.ts
+++ b/backend/src/app/http/controller/health.ts
@@ -2,8 +2,8 @@ import type { ConnectRouter, MethodImpl } from '@connectrpc/connect'
 import {
   HealthService,
   HealthStatus,
-} from '@workspace/generated/connectrpc/health/v1/health_pb'
-import type { IGetHealthStatusUseCase } from '../../../feature/health/application/getHealthStatusUseCase'
+} from '@workspace/generated/connectrpc/health/v1/health_pb.js'
+import type { IGetHealthStatusUseCase } from '../../../feature/health/application/getHealthStatusUseCase.js'
 
 // DI することで Request -> Response の関数をテストできる
 export const createCheckHealthMethod =

--- a/backend/src/app/http/server.ts
+++ b/backend/src/app/http/server.ts
@@ -1,6 +1,6 @@
 import { fastifyConnectPlugin } from '@connectrpc/connect-fastify'
 import { fastify } from 'fastify'
-import routes from './connect'
+import routes from './connect.js'
 
 export type HttpServerOption = {
   host: string

--- a/backend/src/container.ts
+++ b/backend/src/container.ts
@@ -1,5 +1,5 @@
 import * as awilix from 'awilix'
-import { sqliteHealthCheckAdapter } from './feature/health/infrastructure/sqlite'
+import { sqliteHealthCheckAdapter } from './feature/health/infrastructure/sqlite.js'
 
 export const container = awilix.createContainer({
     injectionMode: awilix.InjectionMode.CLASSIC,

--- a/backend/src/feature/health/infrastructure/sqlite.ts
+++ b/backend/src/feature/health/infrastructure/sqlite.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3'
-import type { IHealthCheckPort } from '../application/getHealthStatusUseCase'
+import type { IHealthCheckPort } from '../application/getHealthStatusUseCase.js'
 
 // TODO: repository 化する
 // TODO: SQLITE_APP_DB_PATH が適切なパスであることを確認する

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,4 @@
-import { fastifyHttpServer } from './app/http/server'
+import { fastifyHttpServer } from './app/http/server.js'
 
 fastifyHttpServer.run({
   host: 'localhost',

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "nodenext",
     "noEmit": true
   },
   "include": ["src/**/*.ts"]

--- a/backend/tsup.config.ts
+++ b/backend/tsup.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig(() => ({
-  entry: ['src/index.ts'],
+  entry: ['src/**/*.ts'],
   outDir: 'dist',
   format: ['esm'],
   platform: 'node',
   noExternal: ['@workspace/generated'],
+  bundle: false,
   sourcemap: true,
   dts: false,
   splitting: false,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "workspaces": [
     "frontend",
-    "backend"
+    "backend",
+    "packages/*"
   ],
   "scripts": {
     "dev": "$npm_execpath --parallel --filter frontend --filter backend dev",
@@ -13,7 +14,7 @@
     "lint:codestyle:fix": "biome check --write",
     "lint:buf": "buf lint",
     "lint:buf:fix": "buf format -w && buf lint",
-    "gen:buf": "buf generate"
+    "gen:buf": "buf generate && $npm_execpath --filter @workspace/generated build"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.0",

--- a/packages/generated/.gitignore
+++ b/packages/generated/.gitignore
@@ -1,0 +1,4 @@
+# backend 向けの tsc による生成物
+*.js
+*.d.ts
+*.map

--- a/packages/generated/package.json
+++ b/packages/generated/package.json
@@ -4,7 +4,19 @@
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.15.0",
+  "exports": {
+    "./*": {
+      "import": "./*",
+      "types": "./*.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc"
+  },
   "dependencies": {
     "@bufbuild/protobuf": "^2.7.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/generated/tsconfig.json
+++ b/packages/generated/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "**/*.js", "**/*.d.ts"],
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": ".",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,10 @@ importers:
       '@bufbuild/protobuf':
         specifier: ^2.7.0
         version: 2.7.0
+    devDependencies:
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
 
 packages:
 


### PR DESCRIPTION
https://github.com/jeffijoe/awilix#auto-loading-modules

awilix の loadModules は依存関係を自動でコンテナに登録してくれます。
ただし、実行時に glob にマッチするファイルを探して動作する都合で、bundle すると使えなくなります。

bundle せず、ディレクトリ構成を維持してトランスパイルすることは簡単です。(7f84f3e365da133f82ee506680b9b70a01fe6cc9)

その場合、ESM の import 文が残るので、Node で実行すると module の解決ができません。(`.js` の拡張子が必要)
loadModules をどうしても使いたいので、backend の moduleResolution を `nodenext` にして、import 時の拡張子を必須にしました。(2a47db0c7e8248266e7a4730b4eb34177fe85a30)
(補完はちゃんと効くので不便はないはず)

bundle してない + moduleResolution が node だと、今度は `buf generate` の生成物が import できなくなります (js で出力していないので)。
クライアントでは ts は必要なので、`buf generate` の後に `packages/generated` に tsc をかけるようにしました。(b582d3a2a1bf96b162dceb6c72aec6e5219fbdd3)